### PR TITLE
cronでは--no-autorestartオプションをつける

### DIFF
--- a/lib/define.js
+++ b/lib/define.js
@@ -64,6 +64,7 @@ function define (filename, options = {}) {
         maxRestarts,
         restartDelay,
         maxMemoryRestart,
+        noAutorestart: Boolean(cron),
       })) : subTasks.restart(ctx)
     },
     async stop (ctx) {
@@ -85,7 +86,8 @@ function define (filename, options = {}) {
     },
     async restart (ctx) {
       return pm2('restart', name, {
-        updateEnv: true
+        updateEnv: true,
+        noAutorestart: Boolean(cron),
       })
     },
     async logs (ctx) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Pon task to use pm2
  * @module pon-task-pm2
- * @version 2.2.6
+ * @version 2.2.7
  */
 
 'use strict'

--- a/misc/mocks/mock-script-01.js
+++ b/misc/mocks/mock-script-01.js
@@ -3,4 +3,4 @@
 
 setInterval(() => {
   console.log('hoge')
-})
+}, 100)


### PR DESCRIPTION
pm2@3.2.3では `--cron` に `--no-autorestart` オプションをつけないと無限に restart するため。

https://github.com/Unitech/pm2/issues/4073